### PR TITLE
Fix syntax error in metro.config.js

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -11,8 +11,8 @@ module.exports = {
   resolver: {
     extraNodeModules: {
       stream: require.resolve('readable-stream'),
-      crypto: require.resolve('react-native-crypto-js'),
-      zlib: require.resolve('react-zlib-js'),
+      crypto: require.resolve('react-native-crypto'),
+      zlib: require.resolve('react-native-zlib'),
     },
     sourceExts: [...defaultSourceExts, 'cjs'],
   },


### PR DESCRIPTION
The package react-native-crypto-js does not exist in the npm registry.
The package react-zlib-js does not exist in the npm registry.
