### PR TITLE
Fix logical error (incorrect argument format)

### DIFF
--- a/src/eclipse-wallet-adapter/factories/account-factory.js
+++ b/src/eclipse-wallet-adapter/factories/account-factory.js
@@ -25,7 +25,7 @@ const create = async ({
   await Promise.all(
     enabledNetworks.map(async (network) => {
       const indexes = pathIndexes[network.id] || [0];
-      networksAccounts[network.id] = await createNetworkAccounts({ network, mnemonic, indexes });
+      networksAccounts[network.id] = await createNetworkAccounts([{ network, mnemonic, indexes }]);
       return networksAccounts[network.id];
     })
   );


### PR DESCRIPTION
The function createNetworkAccounts may not create the necessary accounts, which will lead to the absence of accounts for the corresponding networks. This will disrupt the application's functionality, making it impossible to properly manage accounts across different networks.